### PR TITLE
Fix issue #4 - match array not initialized

### DIFF
--- a/expect.c
+++ b/expect.c
@@ -452,11 +452,15 @@ PHP_FUNCTION(expect_expectl)
 		if (z_match && exp_match && exp_match_len > 0) {
 			char *tmp = (char *)emalloc (sizeof(char) * (exp_match_len + 1));
 			strlcpy (tmp, exp_match, exp_match_len + 1);
-			zval_dtor (z_match);
-			array_init(z_match);
 #if PHP_MAJOR_VERSION >= 7
+            z_match = zend_try_array_init(z_match);
+			if (!z_match) {
+				return;
+			}
             add_index_string(z_match, 0, tmp);
 #else
+			zval_dtor (z_match);
+			array_init(z_match);
 			add_index_string(z_match, 0, tmp, 1);
 #endif
 			/* Get case that was matched */


### PR DESCRIPTION
Done like in function php_pcre_match_impl() of PCRE module.