### PR TITLE
Fix Linux-x32 and pure 32-bit build. Fix PHP 5.6-7.3 builds.

### DIFF
--- a/expect.c
+++ b/expect.c
@@ -453,11 +453,15 @@ PHP_FUNCTION(expect_expectl)
 		if (z_match && exp_match && exp_match_len > 0) {
 			char *tmp = (char *)emalloc (sizeof(char) * (exp_match_len + 1));
 			strlcpy (tmp, exp_match, exp_match_len + 1);
-#if PHP_MAJOR_VERSION >= 7
+#if PHP_MAJOR_VERSION > 7 || (PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION >= 4)
             z_match = zend_try_array_init(z_match);
-			if (!z_match) {
-				return;
-			}
+            if (!z_match) {
+                return;
+            }
+            add_index_string(z_match, 0, tmp);
+#elif PHP_MAJOR_VERSION >= 7
+            zval_dtor(z_match);
+            array_init(z_match);
             add_index_string(z_match, 0, tmp);
 #else
 			zval_dtor (z_match);

--- a/expect.c
+++ b/expect.c
@@ -309,12 +309,13 @@ PHP_FUNCTION(expect_expectl)
 	struct exp_case *ecases, *ecases_ptr, matchedcase;
 #if PHP_MAJOR_VERSION >= 7
     zval *z_stream, *z_cases, *z_match=NULL, *z_case, *z_value;
+	zend_ulong key;
 #else
 	zval *z_stream, *z_cases, *z_match=NULL, **z_case, **z_value;
+	ulong key;
 #endif
 	php_stream *stream;
 	int fd, argc;
-	ulong key;
 	
 	if (ZEND_NUM_ARGS() < 2 || ZEND_NUM_ARGS() > 3) { WRONG_PARAM_COUNT; }
 

--- a/expect_fopen_wrapper.c
+++ b/expect_fopen_wrapper.c
@@ -26,6 +26,9 @@
 #if PHP_MAJOR_VERSION >= 7
 php_stream *php_expect_stream_open (php_stream_wrapper *wrapper, const char *command, const char *mode, int options, 
                            zend_string **opened_command, php_stream_context *context STREAMS_DC TSRMLS_DC)
+#elif PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION >= 6
+php_stream *php_expect_stream_open (php_stream_wrapper *wrapper, const char *command, const char *mode, int options,
+							  char **opened_command, php_stream_context *context STREAMS_DC TSRMLS_DC)
 #else
 php_stream *php_expect_stream_open (php_stream_wrapper *wrapper, char *command, char *mode, int options, 
 							  char **opened_command, php_stream_context *context STREAMS_DC TSRMLS_DC)
@@ -36,7 +39,7 @@ php_stream *php_expect_stream_open (php_stream_wrapper *wrapper, char *command, 
 		command += sizeof("expect://")-1;
 	} 
 
-#if PHP_MAJOR_VERSION >= 7
+#if PHP_MAJOR_VERSION >= 7 || (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION >= 6)
     if ((fp = exp_popen((char*)command)) != NULL) {
 #else
 	if ((fp = exp_popen(command)) != NULL) {


### PR DESCRIPTION
Fixes:

expect.c: In function ‘zif_expect_expectl’:
expect.c:354:62: error: passing argument 3 of ‘zend_hash_get_current_key’ from incompatible pointer type [-Wincompatible-pointer-types] 354 | zend_hash_get_current_key(Z_ARRVAL_P(z_cases), NULL, &key); | ^~~~
| |
| ulong * {aka long unsigned int *}
[...]
In file included from /usr/include/php/Zend/zend.h:33, /usr/include/php/Zend/zend_hash.h:275:130: note: expected ‘zend_ulong *’ {aka ‘unsigned int *’} but argument is of type ‘ulong *’ {aka ‘long unsigned int *’} 275 | static zend_always_inline zend_hash_key_type zend_hash_get_current_key(const HashTable *ht, zend_string **str_index, zend_ulong *num_index) {

Fixes:

Build on PHP 5.6-7.3.